### PR TITLE
Display timestamps in Malaysia time; run expiry reminder at 9am MYT

### DIFF
--- a/resources/views/quote/index.blade.php
+++ b/resources/views/quote/index.blade.php
@@ -29,7 +29,7 @@
                 <tbody class="divide-y divide-gray-100 bg-white">
                     @forelse ($quotes as $quote)
                         <tr class="hover:bg-gray-50 {{ $quote->is_read ? '' : 'bg-orange-50/40' }}">
-                            <td class="px-4 py-3 whitespace-nowrap text-gray-500">{{ $quote->created_at->format('d/m/Y H:i') }}</td>
+                            <td class="px-4 py-3 whitespace-nowrap text-gray-500">{{ $quote->created_at->timezone('Asia/Kuala_Lumpur')->format('d/m/Y H:i') }}</td>
                             <td class="px-4 py-3 font-medium text-gray-900 {{ $quote->is_read ? '' : 'font-bold' }}">{{ $quote->nama_pemilik }}</td>
                             <td class="px-4 py-3 text-gray-700">{{ $quote->whatsapp }}</td>
                             <td class="px-4 py-3 text-gray-700 font-medium">{{ $quote->no_plate }}</td>

--- a/resources/views/whatsapp/index.blade.php
+++ b/resources/views/whatsapp/index.blade.php
@@ -39,7 +39,7 @@
                         @endphp
                         <tr class="hover:bg-gray-50">
                             <td class="px-4 py-3 whitespace-nowrap text-gray-500">
-                                {{ $n->sent_at?->format('d/m/Y H:i') }}
+                                {{ $n->sent_at?->timezone('Asia/Kuala_Lumpur')->format('d/m/Y H:i') }}
                             </td>
                             <td class="px-4 py-3">
                                 @if ($n->client)

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,5 +8,7 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-// Send WhatsApp expiry reminders daily at 9am
-Schedule::command('whatsapp:send-expiry-reminders')->dailyAt('09:00');
+// Send WhatsApp expiry reminders daily at 9am Malaysia time
+Schedule::command('whatsapp:send-expiry-reminders')
+    ->dailyAt('09:00')
+    ->timezone('Asia/Kuala_Lumpur');


### PR DESCRIPTION
- WhatsApp log and quote list convert sent_at/created_at to Asia/Kuala_Lumpur
- Expiry reminder scheduler now runs 09:00 MYT (was 09:00 UTC = 5pm MYT)
- DB storage stays UTC; conversion is display-only so existing records stay correct