### PR TITLE
Map AhaPay payment_in_progress; log DOKU signature inputs

### DIFF
--- a/app/Services/Payments/AhaPayGateway.php
+++ b/app/Services/Payments/AhaPayGateway.php
@@ -180,6 +180,7 @@ class AhaPayGateway implements PaymentGateway
             in_array($status, [
                 '', 'pending', 'payment_pending', 'created', 'order_created',
                 'awaiting_payment', 'scoring', 'sent_to_scoring', 'approved',
+                'payment_in_progress',                                   // confirmed live
             ], true) => 'pending',
 
             default => null,   // unknown — caller logs it

--- a/app/Services/Payments/SenangPayGateway.php
+++ b/app/Services/Payments/SenangPayGateway.php
@@ -125,9 +125,27 @@ class SenangPayGateway implements PaymentGateway
         $received     = (string) $request->header('Signature');
 
         if (! hash_equals($expected, $received) && ! hash_equals($rawSignature, $received)) {
+            // TEMPORARY (production diagnosis): DOKU is delivering notifications
+            // but our recompute doesn't match. Log every input so the difference
+            // can be identified, then trim this back to a plain warning.
+            // Still fail-closed — a mismatch is always rejected.
             Log::warning('senangPay (DOKU) signature verification failed.', [
-                'ip'        => $request->ip(),
-                'path_info' => $request->getPathInfo(),
+                'ip'                => $request->ip(),
+                'received'          => $received,
+                'expected'          => $expected,
+                'expected_noprefix' => $rawSignature,
+                'client_id_header'  => $request->header('Client-Id'),
+                'client_id_config'  => config('services.senangpay.client_id'),
+                'request_id'        => $request->header('Request-Id'),
+                'request_timestamp' => $request->header('Request-Timestamp'),
+                'digest_header'     => $request->header('Digest'),
+                'digest_computed'   => $digest,
+                'path_info'         => $request->getPathInfo(),
+                'request_uri'       => $request->getRequestUri(),
+                'full_url'          => $request->fullUrl(),
+                'content_type'      => $request->header('Content-Type'),
+                'all_headers'       => array_keys($request->headers->all()),
+                'raw_body'          => $rawBody,
             ]);
             throw new GatewayException('senangPay signature verification failed.');
         }


### PR DESCRIPTION
The new unrecognised-status warning surfaced AhaPay's "payment_in_progress" within minutes — a legitimate in-flight state, so map it to pending rather than warning on every poll.

DOKU is now delivering notifications to the production domain but our HMAC recompute rejects them, so senangPay payments (e.g. PAY-2026-0023) never settle. Log every signature input on mismatch so the difference can be identified from a real notification instead of guessed. Still fail-closed. Trim this back once the cause is known — it logs the raw body.