### PR TITLE
Add Turnstile to the quote request form

### DIFF
--- a/app/Http/Controllers/QuoteRequestController.php
+++ b/app/Http/Controllers/QuoteRequestController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Mail\QuoteRequestMail;
 use App\Models\QuoteRequest;
+use App\Services\TurnstileService;
 use App\Services\WhatsAppService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -11,6 +12,8 @@ use Illuminate\Support\Facades\Mail;
 
 class QuoteRequestController extends Controller
 {
+    public function __construct(private TurnstileService $turnstile) {}
+
     // ── Public ───────────────────────────────────────────────────────────────
 
     public function create()
@@ -34,6 +37,14 @@ class QuoteRequestController extends Controller
             'jumlah_perlindungan_cermin' => 'nullable|numeric',
             'jenis_pembayaran'           => 'required|string|max:255',
         ]);
+
+        // Captcha sits on the last step, so check it before anything is stored.
+        // Skipped automatically when Turnstile isn't configured.
+        if (! $this->turnstile->verify($request->input('cf-turnstile-response'), $request->ip())) {
+            return back()->withInput()->withErrors([
+                'captcha' => 'Pengesahan keselamatan gagal. Sila cuba lagi.',
+            ]);
+        }
 
         // Normalize perlindungan_tambahan to an array (checkboxes = array, radio = string)
         $tambahan = $request->input('perlindungan_tambahan', []);

--- a/resources/views/quote/create.blade.php
+++ b/resources/views/quote/create.blade.php
@@ -189,6 +189,13 @@
                             </template>
                         </div>
                     </div>
+
+                    @if(config('services.turnstile.site_key'))
+                        <div class="pt-2">
+                            <div class="cf-turnstile" data-sitekey="{{ config('services.turnstile.site_key') }}"></div>
+                            @error('captcha')<p class="mt-1 text-sm text-red-600">{{ $message }}</p>@enderror
+                        </div>
+                    @endif
                 </div>
 
                 <!-- ── Navigation ───────────────────────────────────────────── -->
@@ -280,6 +287,10 @@
             }
         }
     </script>
+
+    @if(config('services.turnstile.site_key'))
+        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+    @endif
 
     <style>[x-cloak]{display:none!important}</style>
 </x-public-layout>


### PR DESCRIPTION
The public sebut harga form had no bot protection. Put the widget at the end of step 4 (payment selection), just above the submit button, and verify the token in the controller before anything is stored or any email/WhatsApp is sent.

Matches the payment form's behaviour: the widget only renders when Turnstile is configured, and verification is skipped (with a logged warning) when it isn't, so local and staging still work.