### PR TITLE
Allow deleting a quote request from the admin list

### DIFF
--- a/app/Http/Controllers/QuoteRequestController.php
+++ b/app/Http/Controllers/QuoteRequestController.php
@@ -129,4 +129,15 @@ class QuoteRequestController extends Controller
 
         return back();
     }
+
+    public function destroy(QuoteRequest $quoteRequest)
+    {
+        $reference = $quoteRequest->nama_pemilik . ' (' . $quoteRequest->no_plate . ')';
+
+        $quoteRequest->delete();
+
+        return redirect()
+            ->route('quote-requests.index')
+            ->with('success', "Permohonan {$reference} telah dipadam.");
+    }
 }

--- a/resources/views/quote/index.blade.php
+++ b/resources/views/quote/index.blade.php
@@ -46,10 +46,21 @@
                                 </form>
                             </td>
                             <td class="px-4 py-3 text-center">
-                                <a href="{{ route('quote-requests.show', $quote) }}"
-                                   class="inline-flex items-center rounded-md bg-orange-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-orange-700">
-                                    View
-                                </a>
+                                <div class="flex items-center justify-center gap-2">
+                                    <a href="{{ route('quote-requests.show', $quote) }}"
+                                       class="inline-flex items-center rounded-md bg-orange-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-orange-700">
+                                        View
+                                    </a>
+                                    <form method="POST" action="{{ route('quote-requests.destroy', $quote) }}" class="inline"
+                                          onsubmit="return confirm('Padam permohonan daripada {{ addslashes($quote->nama_pemilik) }} ({{ $quote->no_plate }})? Tindakan ini tidak boleh dibatalkan.')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit"
+                                                class="inline-flex items-center rounded-md bg-red-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-red-700">
+                                            Padam
+                                        </button>
+                                    </form>
+                                </div>
                             </td>
                         </tr>
                     @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,6 +73,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/quote-requests', [QuoteRequestController::class, 'index'])->name('quote-requests.index');
     Route::get('/quote-requests/{quoteRequest}', [QuoteRequestController::class, 'show'])->name('quote-requests.show');
     Route::patch('/quote-requests/{quoteRequest}/toggle-read', [QuoteRequestController::class, 'toggleRead'])->name('quote-requests.toggle-read');
+    Route::delete('/quote-requests/{quoteRequest}', [QuoteRequestController::class, 'destroy'])->name('quote-requests.destroy');
 
     // Settings
     Route::get('/settings', [SettingController::class, 'edit'])->name('settings.edit');


### PR DESCRIPTION
Adds a Padam button beside View on /quote-requests, with a JS confirm naming the applicant and plate so the wrong row isn't removed by accident. Redirects back to the list with a confirmation message.