### PR TITLE
Verify DOKU notifications against the Request-Target they send

### DIFF
--- a/app/Services/Payments/SenangPayGateway.php
+++ b/app/Services/Payments/SenangPayGateway.php
@@ -26,6 +26,10 @@ use Illuminate\Support\Str;
  *   digest    = base64( sha256(rawBody) )                    // omit for GET
  *   component = "Client-Id:{id}\nRequest-Id:{rid}\nRequest-Timestamp:{ts}\nRequest-Target:{path}\nDigest:{digest}"
  *   signature = "HMACSHA256=" . base64( hmac_sha256(component, secretKey) )
+ *
+ * On the inbound notification DOKU sends the Request-Target it signed with as a
+ * header of that name, and sends the Signature without the "HMACSHA256=" prefix.
+ * Verification uses that header rather than assuming our own request path.
  */
 class SenangPayGateway implements PaymentGateway
 {
@@ -108,44 +112,52 @@ class SenangPayGateway implements PaymentGateway
         $secretKey = config('services.senangpay.secret_key');
         $rawBody   = $request->getContent();
 
-        // DOKU signs its notification with the same scheme, using the path it
-        // POSTs to on our server as the Request-Target. Recompute and compare.
-        $digest = base64_encode(hash('sha256', $rawBody, true));
+        $digest   = base64_encode(hash('sha256', $rawBody, true));
+        $received = (string) $request->header('Signature');
 
-        $component = "Client-Id:" . $request->header('Client-Id') . "\n"
-            . "Request-Id:" . $request->header('Request-Id') . "\n"
-            . "Request-Timestamp:" . $request->header('Request-Timestamp') . "\n"
-            . "Request-Target:" . $request->getPathInfo() . "\n"
-            . "Digest:" . $digest;
+        // DOKU tells us which Request-Target it signed with, in a header of that
+        // name — trust that first. We used to assume it was the path we were
+        // POSTed to, which silently rejected every live notification.
+        //
+        // Taking the target from a header is safe: forging the signature still
+        // requires the secret key, so a wrong or hostile value just fails to match.
+        $targets = array_values(array_filter(array_unique([
+            $request->header('Request-Target'),
+            $request->getPathInfo(),      // /webhooks/payments/senangpay
+            $request->getRequestUri(),    // as above, plus any query string
+            $request->fullUrl(),
+        ])));
 
-        // DOKU sends the Signature as raw base64 (no "HMACSHA256=" prefix) on
-        // notifications, though its request docs show the prefix — accept either.
-        $rawSignature = base64_encode(hash_hmac('sha256', $component, $secretKey, true));
-        $expected     = 'HMACSHA256=' . $rawSignature;
-        $received     = (string) $request->header('Signature');
+        foreach ($targets as $target) {
+            $component = "Client-Id:" . $request->header('Client-Id') . "\n"
+                . "Request-Id:" . $request->header('Request-Id') . "\n"
+                . "Request-Timestamp:" . $request->header('Request-Timestamp') . "\n"
+                . "Request-Target:" . $target . "\n"
+                . "Digest:" . $digest;
 
-        if (! hash_equals($expected, $received) && ! hash_equals($rawSignature, $received)) {
-            // TEMPORARY (production diagnosis): DOKU is delivering notifications
-            // but our recompute doesn't match. Log every input so the difference
-            // can be identified, then trim this back to a plain warning.
-            // Still fail-closed — a mismatch is always rejected.
+            // DOKU sends the Signature as raw base64 (no "HMACSHA256=" prefix) on
+            // notifications, though its request docs show the prefix — accept either.
+            $rawSignature = base64_encode(hash_hmac('sha256', $component, $secretKey, true));
+
+            if (hash_equals('HMACSHA256=' . $rawSignature, $received) || hash_equals($rawSignature, $received)) {
+                $matched = $target;
+                break;
+            }
+        }
+
+        if (! isset($matched)) {
+            // Fail closed. Deliberately no request body here — it carries the
+            // payer's name, email and phone, which must not reach the log file.
             Log::warning('senangPay (DOKU) signature verification failed.', [
                 'ip'                => $request->ip(),
                 'received'          => $received,
-                'expected'          => $expected,
-                'expected_noprefix' => $rawSignature,
+                'targets_tried'     => $targets,
                 'client_id_header'  => $request->header('Client-Id'),
-                'client_id_config'  => config('services.senangpay.client_id'),
+                'client_id_matches' => $request->header('Client-Id') === config('services.senangpay.client_id'),
                 'request_id'        => $request->header('Request-Id'),
                 'request_timestamp' => $request->header('Request-Timestamp'),
-                'digest_header'     => $request->header('Digest'),
                 'digest_computed'   => $digest,
-                'path_info'         => $request->getPathInfo(),
-                'request_uri'       => $request->getRequestUri(),
-                'full_url'          => $request->fullUrl(),
-                'content_type'      => $request->header('Content-Type'),
-                'all_headers'       => array_keys($request->headers->all()),
-                'raw_body'          => $rawBody,
+                'body_bytes'        => strlen($rawBody),
             ]);
             throw new GatewayException('senangPay signature verification failed.');
         }

--- a/tests/Feature/SenangPayGatewayTest.php
+++ b/tests/Feature/SenangPayGatewayTest.php
@@ -147,6 +147,44 @@ class SenangPayGatewayTest extends TestCase
         $this->assertSame('pending', $result['status']);
     }
 
+    /**
+     * The live production failure: DOKU signs with a Request-Target of its own
+     * choosing and announces it in a header, and omits the "HMACSHA256=" prefix.
+     * We assumed the target was our own request path, so every real notification
+     * was rejected and paid orders sat pending.
+     */
+    public function test_verify_callback_uses_the_request_target_header_doku_sends(): void
+    {
+        $request = $this->signedNotification(
+            ['order' => ['invoice_number' => 'PAY-2026-0024'], 'transaction' => ['status' => 'SUCCESS']],
+            target: '/api/v1/notification/webhook',
+            prefix: false,
+        );
+
+        $result = app(SenangPayGateway::class)->verifyCallback($request);
+
+        $this->assertSame('paid', $result['status']);
+        $this->assertSame('PAY-2026-0024', $result['reference']);
+    }
+
+    /**
+     * Trusting that header must not become a bypass — it only selects which
+     * string is signed, and forging still requires the secret key.
+     */
+    public function test_request_target_header_is_not_a_signature_bypass(): void
+    {
+        $request = $this->signedNotification(
+            ['order' => ['invoice_number' => 'PAY-2026-0024'], 'transaction' => ['status' => 'SUCCESS']],
+            secret: 'SK-attacker-key',
+            target: '/api/v1/notification/webhook',
+            prefix: false,
+        );
+
+        $this->expectException(GatewayException::class);
+
+        app(SenangPayGateway::class)->verifyCallback($request);
+    }
+
     public function test_verify_callback_rejects_a_forged_signature(): void
     {
         // Correctly built body, but the signature is computed with the wrong key.
@@ -185,8 +223,12 @@ class SenangPayGatewayTest extends TestCase
      * Build a Request carrying a DOKU-style notification signed exactly the way
      * the driver's verifier recomputes it (Request-Target = our webhook path).
      */
-    private function signedNotification(array $payload, ?string $secret = null): Request
-    {
+    private function signedNotification(
+        array $payload,
+        ?string $secret = null,
+        ?string $target = null,
+        bool $prefix = true,
+    ): Request {
         $secret = $secret ?? self::SECRET;
         $path   = '/webhooks/payments/senangpay';
         $body   = json_encode($payload);
@@ -199,18 +241,25 @@ class SenangPayGatewayTest extends TestCase
         $component = "Client-Id:{$clientId}\n"
             . "Request-Id:{$requestId}\n"
             . "Request-Timestamp:{$timestamp}\n"
-            . "Request-Target:{$path}\n"
+            . "Request-Target:" . ($target ?? $path) . "\n"
             . "Digest:{$digest}";
 
-        $signature = 'HMACSHA256=' . base64_encode(hash_hmac('sha256', $component, $secret, true));
+        $signature = base64_encode(hash_hmac('sha256', $component, $secret, true));
 
-        return Request::create($path, 'POST', [], [], [], [
+        $headers = [
             'HTTP_CLIENT_ID'         => $clientId,
             'HTTP_REQUEST_ID'        => $requestId,
             'HTTP_REQUEST_TIMESTAMP' => $timestamp,
-            'HTTP_SIGNATURE'         => $signature,
+            'HTTP_SIGNATURE'         => $prefix ? 'HMACSHA256=' . $signature : $signature,
             'CONTENT_TYPE'           => 'application/json',
-        ], $body);
+        ];
+
+        // DOKU announces the target it signed with; only send it when set.
+        if ($target !== null) {
+            $headers['HTTP_REQUEST_TARGET'] = $target;
+        }
+
+        return Request::create($path, 'POST', [], [], [], $headers, $body);
     }
 
     /**


### PR DESCRIPTION
DOKU signs the notification with a Request-Target of its own choosing and announces it in a header of that name. We assumed the target was the path it POSTed to on our server, so the recomputed HMAC never matched and every live notification was rejected — PAY-2026-0023/0024/0025 were paid at the gateway but left pending, and no payment_received WhatsApp went out.

Verification now walks the announced target first, then the previous path guesses as a fallback. Reading the target from a header is not a bypass: forging still requires the secret key, so a hostile value simply fails to match. Kept fail-closed.

Also drops the raw request body from the failure log — it carries the payer's name, email and phone — and logs the targets tried instead, which is what actually identifies a future mismatch.