### PR TITLE
Send the payment_received WhatsApp to the admin, not the payer

### DIFF
--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -57,12 +57,13 @@ class WhatsAppService
     // ── Payment ───────────────────────────────────────────────────────────────
 
     /**
-     * Notify the payer that their payment succeeded.
-     * Template payment_received — {{1}} name, {{2}} amount, {{3}} payment method.
+     * Alert the admin that a payment succeeded — this goes to the admin number,
+     * never to the payer. The template's {{1}} is the payer's name, so the admin
+     * can see who paid: {{1}} name, {{2}} amount, {{3}} payment method.
      */
     public function notifyPaymentReceived(Payment $payment): void
     {
-        $phone  = $this->normalizePhone($payment->payer_phone);
+        $phone  = $this->normalizePhone($this->adminNumber);
         $method = Payment::GATEWAY_LABELS[$payment->gateway] ?? ucfirst($payment->gateway);
 
         $params = [
@@ -82,13 +83,13 @@ class WhatsAppService
             }
         } else {
             $status = 'failed';
-            $error  = 'No valid phone number on record.';
+            $error  = 'Admin WhatsApp number is not configured.';
         }
 
         WhatsAppNotification::create([
             'client_id'       => null,
             'type'            => 'payment_received',
-            'recipient_phone' => $phone ?? $payment->payer_phone,
+            'recipient_phone' => $phone ?? $this->adminNumber,
             'message'         => 'payment_received: ' . implode(' | ', $params),
             'status'          => $status,
             'error'           => $error,

--- a/database/migrations/2026_07_21_090000_add_payment_received_to_whatsapp_notifications.php
+++ b/database/migrations/2026_07_21_090000_add_payment_received_to_whatsapp_notifications.php
@@ -1,23 +1,34 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     /**
      * Payment notifications aren't tied to a Client, and need a new type value.
-     * Raw MySQL ALTERs (matching the existing enum migrations); no-op on other
-     * drivers so the sqlite test database doesn't choke on ENUM/MODIFY syntax.
+     *
+     * MySQL gets raw ALTERs to match the existing enum migrations. Other drivers
+     * can't parse ENUM/MODIFY, but skipping them entirely left sqlite with a
+     * NOT NULL client_id — so every payment_received insert threw in tests, was
+     * swallowed by the caller's try/catch, and the logging went untested.
+     * Apply the same shape through the schema builder instead.
      */
     public function up(): void
     {
-        if (DB::getDriverName() !== 'mysql') {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE whatsapp_notifications MODIFY COLUMN client_id BIGINT UNSIGNED NULL");
+            DB::statement("ALTER TABLE whatsapp_notifications MODIFY COLUMN type ENUM('expiry_30d', 'expiry_14d', 'expiry_3d', 'policy_created', 'policy_updated', 'policy_renewed', 'payment_received')");
+
             return;
         }
 
-        DB::statement("ALTER TABLE whatsapp_notifications MODIFY COLUMN client_id BIGINT UNSIGNED NULL");
-        DB::statement("ALTER TABLE whatsapp_notifications MODIFY COLUMN type ENUM('expiry_30d', 'expiry_14d', 'expiry_3d', 'policy_created', 'policy_updated', 'policy_renewed', 'payment_received')");
+        Schema::table('whatsapp_notifications', function (Blueprint $table) {
+            $table->unsignedBigInteger('client_id')->nullable()->change();
+            $table->string('type')->change();   // drops the enum check constraint
+        });
     }
 
     public function down(): void

--- a/tests/Feature/PaymentWhatsAppTest.php
+++ b/tests/Feature/PaymentWhatsAppTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Payment;
+use App\Models\WhatsAppNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The payment_received WhatsApp.
+ *
+ * This is an internal alert: it tells the admin that money arrived. It shipped
+ * pointing at the payer's own number by mistake, so every successful payer got
+ * a message meant for staff. These lock the recipient down.
+ */
+class PaymentWhatsAppTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ADMIN = '60123456789';
+    private const PAYER = '0176295764';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('services.whatsapp', [
+            'phone_number_id' => '1234567890',
+            'access_token'    => 'test-token',
+            'admin_number'    => self::ADMIN,
+        ]);
+
+        Http::fake(['graph.facebook.com/*' => Http::response(['messages' => [['id' => 'wamid.test']]], 200)]);
+    }
+
+    private function pendingPayment(): Payment
+    {
+        return Payment::create([
+            'reference'   => 'PAY-2026-0025',
+            'payer_name'  => 'NURAZLINDA BINTI OTHMAN',
+            'payer_email' => 'azlynn35@example.com',
+            'payer_phone' => self::PAYER,
+            'address'     => 'No 1, Jalan Test',
+            'amount'      => 1002.12,
+            'currency'    => 'MYR',
+            'gateway'     => 'senangpay',
+            'status'      => 'pending',
+        ]);
+    }
+
+    public function test_it_notifies_the_admin_and_never_the_payer(): void
+    {
+        $this->pendingPayment()->update(['status' => 'paid', 'paid_at' => now()]);
+
+        Http::assertSent(function ($request) {
+            $to = $request['to'];
+
+            // The payer's number must not appear in any form.
+            $this->assertNotSame(self::PAYER, $to);
+            $this->assertNotSame('6' . ltrim(self::PAYER, '0'), $to);
+
+            return $to === self::ADMIN
+                && $request['template']['name'] === 'payment_received';
+        });
+    }
+
+    /** {{1}} name, {{2}} amount, {{3}} payment method — as the template expects. */
+    public function test_it_sends_the_payer_name_amount_and_method_as_parameters(): void
+    {
+        $this->pendingPayment()->update(['status' => 'paid', 'paid_at' => now()]);
+
+        Http::assertSent(function ($request) {
+            $values = array_column($request['template']['components'][0]['parameters'], 'text');
+
+            return $values === ['NURAZLINDA BINTI OTHMAN', '1002.12', 'Grab PayLater'];
+        });
+    }
+
+    public function test_the_log_records_the_admin_as_recipient(): void
+    {
+        $this->pendingPayment()->update(['status' => 'paid', 'paid_at' => now()]);
+
+        $log = WhatsAppNotification::where('type', 'payment_received')->sole();
+
+        $this->assertSame(self::ADMIN, $log->recipient_phone);
+        $this->assertSame('sent', $log->status);
+    }
+
+    /** Only the transition to paid fires it — not every save on a paid payment. */
+    public function test_it_fires_once_and_only_on_becoming_paid(): void
+    {
+        $payment = $this->pendingPayment();
+
+        $payment->update(['status' => 'paid', 'paid_at' => now()]);
+        $payment->update(['failure_reason' => 'touched again']);
+
+        $this->assertSame(1, WhatsAppNotification::where('type', 'payment_received')->count());
+    }
+
+    public function test_a_payment_that_fails_sends_nothing(): void
+    {
+        $this->pendingPayment()->update(['status' => 'failed']);
+
+        Http::assertNothingSent();
+        $this->assertSame(0, WhatsAppNotification::count());
+    }
+}


### PR DESCRIPTION
This alert exists to tell staff that money arrived, but it was addressed to payer_phone — so every successful payer received a message meant for us, and the admin got no notification at all.

Also fixes the migration that made client_id nullable: it returned early on any non-MySQL driver, so the sqlite test database kept NOT NULL and every payment_received insert threw. Payment::booted() catches Throwable to keep a messaging failure from breaking payment processing, so it failed silently and the logging was never covered. Non-MySQL drivers now get the same shape via the schema builder.