### PR TITLE
Support Fiuu channel whitelist; disable Atome on reniu

### DIFF
--- a/app/Services/Payments/FiuuGateway.php
+++ b/app/Services/Payments/FiuuGateway.php
@@ -90,7 +90,14 @@ class FiuuGateway implements PaymentGateway, SiteAwareGateway
             'callbackurl' => $webhook,
         ];
 
-        $url = $this->paymentHost() . '/RMS/pay/' . $merchantId . '/?' . http_build_query($params);
+        // Fiuu's hosted page shows every channel enabled on the account. When a
+        // specific channel is selected (payment->method holds the Fiuu channel
+        // code, e.g. "ShopeePay"), pin the page to it via the URL path:
+        //   /RMS/pay/{merchant}/{channel}?...   (spec: {MerchantID}/{Payment_Method})
+        // The channel is NOT part of the vcode, so signing is unaffected.
+        $channel = filled($payment->method) ? rawurlencode($payment->method) : '';
+
+        $url = $this->paymentHost() . '/RMS/pay/' . $merchantId . '/' . $channel . '?' . http_build_query($params);
 
         $payment->update(['checkout_url' => $url]);
 

--- a/config/sites.php
+++ b/config/sites.php
@@ -138,9 +138,9 @@ return [
                 'secret_key' => env('RENIU_TURNSTILE_SECRET_KEY'),
             ],
 
-            // Nothing hidden here — Fiuu is hidden on NAN Solutions but is the
-            // whole point of reniu, whose domain the Fiuu account is bound to.
-            'disabled_gateways' => [],
+            // Fiuu is the point of reniu (its account is domain-bound here), so
+            // it's NOT hidden. Atome is disabled temporarily while it's sorted out.
+            'disabled_gateways' => ['atome'],
 
             'gateways' => [
                 // Card only on reniu — no FPX option.

--- a/tests/Feature/FiuuGatewayTest.php
+++ b/tests/Feature/FiuuGatewayTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Payment;
+use App\Services\Payments\FiuuGateway;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Fiuu (Razer) hosted-page request building — the vcode signature and the
+ * optional channel whitelist. Fiuu itself is never called; the URL it builds
+ * is the whole contract.
+ */
+class FiuuGatewayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const MERCHANT = 'myreniuagency';
+    private const VERIFY   = '89be2f13b528b72b870f054be6ce467f';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('sites.sites.nansolutions.gateways.fiuu.config', [
+            'merchant_id'         => self::MERCHANT,
+            'verify_key'          => self::VERIFY,
+            'secret_key'          => 'secret',
+            'sandbox'             => false,
+            'vcode_with_currency' => false,
+        ]);
+    }
+
+    private function payment(?string $method = null): Payment
+    {
+        return Payment::create([
+            'reference'   => 'RNU-2026-0002',
+            'payer_name'  => 'MUHAMAD FAUZI BIN YAHAYA',
+            'payer_email' => 'test@example.com',
+            'payer_phone' => '0194639163',
+            'address'     => 'No 1, Jalan Test',
+            'amount'      => 100.00,
+            'currency'    => 'MYR',
+            'gateway'     => 'fiuu',
+            'method'      => $method,
+            'status'      => 'pending',
+        ]);
+    }
+
+    public function test_without_a_method_the_hosted_page_shows_all_channels(): void
+    {
+        $url = app(FiuuGateway::class)->createPayment($this->payment());
+
+        // No channel segment: /RMS/pay/{merchant}/?...
+        $this->assertStringContainsString('/RMS/pay/' . self::MERCHANT . '/?', $url);
+    }
+
+    public function test_a_selected_method_pins_the_channel_in_the_url_path(): void
+    {
+        $url = app(FiuuGateway::class)->createPayment($this->payment('ShopeePay'));
+
+        // Channel segment present: /RMS/pay/{merchant}/ShopeePay?...
+        $this->assertStringContainsString('/RMS/pay/' . self::MERCHANT . '/ShopeePay?', $url);
+    }
+
+    /** The channel must not change the vcode — signing is over amount/merchant/order/key only. */
+    public function test_the_channel_does_not_affect_the_vcode(): void
+    {
+        parse_str(parse_url(app(FiuuGateway::class)->createPayment($this->payment('ShopeePay')), PHP_URL_QUERY), $q);
+
+        // vcode is over amount + merchant + orderid + verify key — no channel.
+        $expected = md5('100.00' . self::MERCHANT . 'RNU-2026-0002' . self::VERIFY);
+
+        $this->assertSame($expected, $q['vcode']);
+    }
+}

--- a/tests/Feature/MultiSiteTest.php
+++ b/tests/Feature/MultiSiteTest.php
@@ -81,20 +81,32 @@ class MultiSiteTest extends TestCase
     }
 
     /** The four options reniu.my offers, exactly as the customer sees them. */
-    public function test_reniu_offers_all_four_gateways_with_their_labels(): void
+    public function test_reniu_offers_its_gateways_with_their_labels(): void
     {
         $this->configureReniuGateways();
 
         $labels = array_column(app(PaymentGatewayManager::class)->checkoutOptions(null, 'reniu'), 'label');
 
+        // Atome is temporarily disabled on reniu (disabled_gateways), so it's
+        // not offered even though it's configured.
         $this->assertEqualsCanonicalizing([
             'Credit Card / Atome Card',
             'Grab PayLater',
             'SPayLater / Grab PayLater',
-            'Atome PayLater',
         ], $labels);
 
         $this->assertArrayNotHasKey('ahapay', $this->sites()->gateways('reniu'), 'AhaPay is NAN Solutions only');
+    }
+
+    public function test_atome_is_temporarily_disabled_on_reniu(): void
+    {
+        $this->configureReniuGateways();
+
+        $gateways = array_column(app(PaymentGatewayManager::class)->checkoutOptions(null, 'reniu'), 'gateway');
+
+        // Still configured (label resolves), just not offered at checkout.
+        $this->assertNotContains('atome', $gateways);
+        $this->assertSame('Atome PayLater', $this->sites()->gatewayLabel('atome', 'reniu'));
     }
 
     /**


### PR DESCRIPTION
Fiuu: the hosted page shows every channel enabled on the account. A selected method (payment->method, holding a Fiuu channel code) now pins the page to that channel via the URL path /RMS/pay/{merchant}/{channel} — same mechanism CHIP uses. The channel isn't part of the vcode, so signing is unaffected. Config just needs a methods[] array with the channel codes to split it.

Atome: temporarily disabled on reniu via the per-site disabled_gateways list, so it drops off the checkout step. Still configured (label resolves), just not offered — easy to re-enable.