### PR TITLE
Give reniu its own company identity, WhatsApp template, and drop Artikel

### DIFF
--- a/app/Services/SiteManager.php
+++ b/app/Services/SiteManager.php
@@ -152,6 +152,16 @@ class SiteManager
     }
 
     /**
+     * Company legal identity for the landing contact block and the legal pages:
+     * legal('name'), legal('entity'), legal('registration'), legal('address'),
+     * legal('email'). Kept per-site so reniu.my shows its own entity.
+     */
+    public function legal(?string $key = null, ?string $site = null): mixed
+    {
+        return $this->config('legal' . ($key ? ".{$key}" : ''), null, $site);
+    }
+
+    /**
      * Name on the copyright line. Separate from companyName() because a site can
      * trade under its own brand while the copyright stays with the operating
      * company — reniu.my shows the Reniu logo but the NAN Solutions copyright.

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -66,6 +66,9 @@ class WhatsAppService
         $phone  = $this->normalizePhone($this->adminNumber);
         $method = Payment::GATEWAY_LABELS[$payment->gateway] ?? ucfirst($payment->gateway);
 
+        // reniu.my payments use their own approved template; same three variables.
+        $template = $payment->site === 'reniu' ? 'payment_received_reniu' : 'payment_received';
+
         $params = [
             $payment->payer_name,
             number_format((float) $payment->amount, 2, '.', ''),
@@ -76,7 +79,7 @@ class WhatsAppService
         $error  = null;
 
         if ($phone) {
-            $result = $this->callTemplate($phone, 'payment_received', $params);
+            $result = $this->callTemplate($phone, $template, $params);
             if (! $result['success']) {
                 $status = 'failed';
                 $error  = $result['error'];
@@ -90,7 +93,7 @@ class WhatsAppService
             'client_id'       => null,
             'type'            => 'payment_received',
             'recipient_phone' => $phone ?? $this->adminNumber,
-            'message'         => 'payment_received: ' . implode(' | ', $params),
+            'message'         => $template . ': ' . implode(' | ', $params),
             'status'          => $status,
             'error'           => $error,
             'sent_at'         => now(),

--- a/config/sites.php
+++ b/config/sites.php
@@ -45,6 +45,18 @@ return [
             'company' => null,
             'logo'    => null,
 
+            // Company identity shown on the landing contact block and the legal
+            // pages. Kept per-site so reniu.my carries its own entity.
+            'legal' => [
+                'name'         => 'Nan Solutions',            // as written in policy prose
+                'entity'       => 'NAN SOLUTIONS',            // uppercase, contact/footer
+                'registration' => '202003286749 | SA0554424-W',
+                // The registered/DPO address shown on the legal pages (the landing
+                // shows the office address separately, and is left as-is).
+                'address'      => 'No 1115, Persiaran Chandan 2/11,<br>Taman Chandan Puteri Fasa 4,<br>33000 Kuala Kangsar, Perak.',
+                'email'        => 'hello@nansolutions.com.my',
+            ],
+
             'turnstile' => [
                 'site_key'   => env('TURNSTILE_SITE_KEY'),
                 'secret_key' => env('TURNSTILE_SECRET_KEY'),
@@ -132,6 +144,14 @@ return [
 
             // Uppercase on the copyright line, matching how the brand is set there.
             'copyright' => 'RENIU',
+
+            'legal' => [
+                'name'         => 'Reniu',
+                'entity'       => 'MY RENIU AGENCY',
+                'registration' => '202603051585 (003827443-P)',
+                'address'      => 'NO I-15, FASA 1D1, JALAN SM 1D/4,<br>32040 SERI MANJUNG, PERAK.',
+                'email'        => 'hello@reniu.my',
+            ],
 
             'turnstile' => [
                 'site_key'   => env('RENIU_TURNSTILE_SITE_KEY'),

--- a/resources/views/legal/cancellation-refund.blade.php
+++ b/resources/views/legal/cancellation-refund.blade.php
@@ -1,5 +1,6 @@
 <x-legal-layout title="Cancellation & Refund Policy">
-    <p>Have a question regarding NAN SOLUTIONS's refund policy? Please read below.</p>
+    @php $co = site()->legal('name'); @endphp
+    <p>Have a question regarding {{ $co }}'s refund policy? Please read below.</p>
 
     <h2>Refund Process</h2>
     <ul>

--- a/resources/views/legal/privacy-policy.blade.php
+++ b/resources/views/legal/privacy-policy.blade.php
@@ -1,5 +1,6 @@
 <x-legal-layout title="Privacy Policy">
-    <p>This Privacy Policy (“Policy”) describes how Nan Solutions, its respective subsidiaries, affiliates, associated companies and jointly controlled entities (collectively “Nan Solutions”, “we”, “us” or “our”) collect, use, process and disclose your Personal Data through the use of Nan Solutions Websites (including all mobile applications and websites operated by Nan Solutions (respectively “Apps” and “Websites”), products, features and other services globally (collectively, “Services”).</p>
+    @php $co = site()->legal('name'); @endphp
+    <p>This Privacy Policy (“Policy”) describes how {{ $co }}, its respective subsidiaries, affiliates, associated companies and jointly controlled entities (collectively “{{ $co }}”, “we”, “us” or “our”) collect, use, process and disclose your Personal Data through the use of {{ $co }} Websites (including all mobile applications and websites operated by {{ $co }} (respectively “Apps” and “Websites”), products, features and other services globally (collectively, “Services”).</p>
 
     <p>This Policy applies to our customers, passengers, agents, vendors, suppliers, partners (such as referral and business partners), contractors and service providers (collectively “you”, “your” or “yours”).</p>
 
@@ -12,7 +13,7 @@
     <p>We collect your Personal Data when you voluntarily provide it to us. For example, you may provide your Personal Data to us when you:</p>
     <ul>
         <li>fill up a user profile or registration forms;</li>
-        <li>provide information to assess your eligibility to provide services as a Nan Solutions referral-partner;</li>
+        <li>provide information to assess your eligibility to provide services as a {{ $co }} referral-partner;</li>
         <li>earn incentives and cashbacks;</li>
         <li>interact with our social media pages;</li>
         <li>participate in contests or events organised by us;</li>
@@ -56,16 +57,16 @@
     <p>Some of the information that we collect is sensitive in nature. This includes information such as national ID numbers, race, marital status, and your health or religious beliefs. We only collect this information when this is necessary to comply with legal or regulatory requirements.</p>
 
     <h3>In-app image-taking</h3>
-    <p>Some Nan Solutions partners may use mobile cameras to take personal information such as identification card and vehicle grant. The use of such camera is not endorsed or prohibited by Nan Solutions. The collection, use and disclosure of Personal Data obtained from personal mobile cameras is the responsibility of the relevant partner. Please check with the relevant partner if you have any queries about their use of personal cameras.</p>
+    <p>Some {{ $co }} partners may use mobile cameras to take personal information such as identification card and vehicle grant. The use of such camera is not endorsed or prohibited by {{ $co }}. The collection, use and disclosure of Personal Data obtained from personal mobile cameras is the responsibility of the relevant partner. Please check with the relevant partner if you have any queries about their use of personal cameras.</p>
 
     <h3>Personal Data of minors</h3>
-    <p>As a parent or legal guardian, please do not allow minors under your care to submit Personal Data to Nan Solutions. In the event that such Personal Data of a minor is disclosed to Nan Solutions, you hereby consent to the processing of the minor’s Personal Data and accept and agree to be bound by this Policy and take responsibility for his or her actions.</p>
+    <p>As a parent or legal guardian, please do not allow minors under your care to submit Personal Data to {{ $co }}. In the event that such Personal Data of a minor is disclosed to {{ $co }}, you hereby consent to the processing of the minor’s Personal Data and accept and agree to be bound by this Policy and take responsibility for his or her actions.</p>
 
     <h3>When you provide Personal Data of other individuals to us</h3>
     <p>In some situations, you may provide Personal Data of other individuals (such as your spouse, family members or friends) to us. For example, you may add them as your emergency contact. If you provide us with their Personal Data, you represent and warrant that you have obtained their consent for their Personal Data to be collected, used and disclosed as set out in this Policy.</p>
 
     <h2>Use of Personal Data</h2>
-    <p>Nan Solutions may use, combine and process your Personal Data for the following purposes (“Purposes”).</p>
+    <p>{{ $co }} may use, combine and process your Personal Data for the following purposes (“Purposes”).</p>
 
     <h3>Providing services and features</h3>
     <p>Your Personal Data will be used to provide, personalise, maintain and improve our products and services. This includes using your Personal Data to:</p>
@@ -82,7 +83,7 @@
         <li>protect the security or integrity of the Services and any facilities or equipment used to make the Services available;</li>
         <li>process and manage your rewards;</li>
         <li>enable communications between our users;</li>
-        <li>process, manage or verify your application for subscription with Nan Solutions and to provide you with subscribers’ benefits; and</li>
+        <li>process, manage or verify your application for subscription with {{ $co }} and to provide you with subscribers’ benefits; and</li>
         <li>enable our partners to manage and facilitate insurance solutions.</li>
     </ul>
 
@@ -91,7 +92,7 @@
     <ul>
         <li>screening referral-partners before enabling their use of our Services;</li>
         <li>identifying unsafe driving behaviour such as speeding, harsh braking and acceleration, and providing personalised feedback to partners;</li>
-        <li>verifying your identity when you log in to Nan Solutions;</li>
+        <li>verifying your identity when you log in to {{ $co }};</li>
         <li>using device, location, profile, usage and other Personal Data to prevent, detect and combat fraud or unsafe activities;</li>
         <li>monitoring compliance with our terms and conditions, policies and Referral’s Code of Conduct; and</li>
         <li>detecting, preventing and prosecuting crime.</li>
@@ -119,7 +120,7 @@
     <p>We may also use your Personal Data in connection with mergers, acquisitions, joint ventures, sale of company assets, consolidation, restructuring, financing, business asset transactions, or acquisition of all or part of our business by another company.</p>
 
     <h3>Marketing and promotions</h3>
-    <p>We may use your Personal Data to market Nan Solutions and Nan Solutions’s partners’, sponsors’ and advertisers’ products, services, events or promotions. For example, we may:</p>
+    <p>We may use your Personal Data to market {{ $co }} and {{ $co }}’s partners’, sponsors’ and advertisers’ products, services, events or promotions. For example, we may:</p>
     <ul>
         <li>send you alerts, newsletters, updates, mailers, promotional materials, special privileges, festive greetings; and</li>
         <li>notify, invite and manage your participation in our events or activities.</li>
@@ -138,7 +139,7 @@
     <h3>With subsidiaries and affiliates</h3>
     <p>We share Personal Data with our subsidiaries, associated companies, jointly controlled entities and affiliates.</p>
 
-    <h3>With Nan Solutions’s service providers and business partners</h3>
+    <h3>With {{ $co }}’s service providers and business partners</h3>
     <p>We may provide Personal Data to our vendors, consultants, marketing partners, research firms, and other service providers or business partners. This includes:</p>
     <ul>
         <li>payment processors and facilitators;</li>
@@ -146,7 +147,7 @@
         <li>cloud storage providers;</li>
         <li>marketing partners and marketing platform providers;</li>
         <li>data analytics providers;</li>
-        <li>research partners, including those performing surveys or research projects in partnership with Nan Solutions or on Nan Solutions’s behalf;</li>
+        <li>research partners, including those performing surveys or research projects in partnership with {{ $co }} or on {{ $co }}’s behalf;</li>
         <li>agents and referral partners;</li>
         <li>insurance and financing partners; and</li>
         <li>vehicle solutions partners, vendors or third-party vehicle suppliers.</li>
@@ -162,21 +163,19 @@
     <p>Your Personal Data may be transferred from the country, state and city (“Home Country”) in which you are present while using our services to another country, state and city (“Alternate Country”). You understand and consent to the transfer of your Personal Data from your Home Country to the Alternate Country.</p>
 
     <h2>Cookies</h2>
-    <p>Nan Solutions, and third parties with whom we partner, may use cookies, web beacons, tags, scripts, local shared objects such as HTML5 and Flash (sometimes called “flash cookies”), advertising identifiers (including mobile identifiers such as Apple’s IDFA or Google’s Advertising ID) and similar technology (“Cookies”) in connection with your use of the Websites and Apps.</p>
+    <p>{{ $co }}, and third parties with whom we partner, may use cookies, web beacons, tags, scripts, local shared objects such as HTML5 and Flash (sometimes called “flash cookies”), advertising identifiers (including mobile identifiers such as Apple’s IDFA or Google’s Advertising ID) and similar technology (“Cookies”) in connection with your use of the Websites and Apps.</p>
     <p>Cookies may have unique identifiers, and reside, among other places, on your computer or mobile device, in emails we send to you, and on our web pages. Cookies may transmit Personal Data about you and your use of the Service, such as your browser type, search preferences, IP address, data relating to advertisements that have been displayed to you or that you have clicked on, and the date and time of your use. Cookies may be persistent or stored only during an individual session.</p>
-    <p>Nan Solutions may allow third parties to use Cookies on the Websites and Apps to collect the same type of Personal Data for the same purposes Nan Solutions does for itself. Third parties may be able to associate the Personal Data they collect with other Personal Data they have about you from other sources. We do not necessarily have access to or control over the Cookies they use.</p>
+    <p>{{ $co }} may allow third parties to use Cookies on the Websites and Apps to collect the same type of Personal Data for the same purposes {{ $co }} does for itself. Third parties may be able to associate the Personal Data they collect with other Personal Data they have about you from other sources. We do not necessarily have access to or control over the Cookies they use.</p>
     <p>Additionally, we may share non-personally identifiable Personal Data with third parties, such as location data, advertising identifiers, or a cryptographic hash of a common account identifier (such as an email address), to facilitate the display of targeted advertising.</p>
     <p>If you do not wish for your Personal Data to be collected via Cookies on the Websites, you may deactivate cookies by adjusting your internet browser settings to disable, block or deactivate cookies, by deleting your browsing history and clearing the cache from your internet browser. You may also be able to limit our sharing of some of this Personal Data through your mobile device settings.</p>
 
     <h2>Amendments and updates</h2>
-    <p>Nan Solutions shall have the right to modify, update or amend the terms of this Policy at any time by placing the updated Policy on the Websites. By continuing to use the Apps, Websites or Services, purchase products from Nan Solutions or continuing to communicate or engage with Nan Solutions following the modifications, updates or amendments to this Policy, you signify your acceptance of such modifications, updates or amendments.</p>
+    <p>{{ $co }} shall have the right to modify, update or amend the terms of this Policy at any time by placing the updated Policy on the Websites. By continuing to use the Apps, Websites or Services, purchase products from {{ $co }} or continuing to communicate or engage with {{ $co }} following the modifications, updates or amendments to this Policy, you signify your acceptance of such modifications, updates or amendments.</p>
 
     <p>If you have any queries about your personal data, please contact our Data Privacy Officer at:</p>
-    <p><strong>Nan Solutions</strong><br>
-        No 1115, Persiaran Chandan 2/11,<br>
-        Taman Chandan Puteri Fasa 4,<br>
-        33000 Kuala Kangsar, Perak.<br>
-        <a href="https://wa.link/cikhnz" target="_blank" rel="noopener">WhatsApp Us</a></p>
+    <p><strong>{{ site()->legal('entity') }}</strong><br>
+        {!! site()->legal('address') !!}<br>
+        <a href="mailto:{{ site()->legal('email') }}">{{ site()->legal('email') }}</a></p>
 
     <p class="text-sm text-brand-muted">The original of this Privacy Statement is written in the English language. In the event of any conflict between the English and other language versions, the English version shall prevail.</p>
 </x-legal-layout>

--- a/resources/views/legal/service-delivery.blade.php
+++ b/resources/views/legal/service-delivery.blade.php
@@ -1,8 +1,9 @@
 <x-legal-layout title="Service Delivery Policy">
-    <p>At Nan Solutions, we aim to provide a fast and seamless insurance experience for all our clients.</p>
+    @php $co = site()->legal('name'); @endphp
+    <p>At {{ $co }}, we aim to provide a fast and seamless insurance experience for all our clients.</p>
 
     <h2>Policy and Covernote Activation</h2>
-    <p>Once payment is successfully made, Nan Solutions will generate the insurance policy in the system. The covernote will become active immediately, and we will proceed to activate the road tax accordingly.</p>
+    <p>Once payment is successfully made, {{ $co }} will generate the insurance policy in the system. The covernote will become active immediately, and we will proceed to activate the road tax accordingly.</p>
 
     <h2>Digital Roadtax</h2>
     <p>Customers who choose the digital option will receive their digital covernote and roadtax via email or WhatsApp. No hardcopy of the covernote or roadtax will be delivered or posted.</p>

--- a/resources/views/reniu-landing.blade.php
+++ b/resources/views/reniu-landing.blade.php
@@ -87,7 +87,6 @@
                     <a href="#utama" class="hover:text-white">Utama</a>
                     <a href="#tentang" class="hover:text-white">Tentang Kami</a>
                     <a href="#rakan" class="hover:text-white">Rakan Insurans</a>
-                    <a href="#blog" class="hover:text-white">Blog</a>
                     <a href="#hubungi" class="hover:text-white">Hubungi Kami</a>
                     <div class="relative" x-data="{ t: false }" @mouseenter="t=true" @mouseleave="t=false" @click.outside="t=false">
                         <button @click="t=!t" class="flex items-center gap-1 uppercase hover:text-white">
@@ -119,7 +118,6 @@
                 <a href="#utama" class="block px-3 py-2.5 rounded hover:bg-white/15">Utama</a>
                 <a href="#tentang" class="block px-3 py-2.5 rounded hover:bg-white/15">Tentang Kami</a>
                 <a href="#rakan" class="block px-3 py-2.5 rounded hover:bg-white/15">Rakan Insurans</a>
-                <a href="#blog" class="block px-3 py-2.5 rounded hover:bg-white/15">Blog</a>
                 <a href="{{ route('pay.create') }}" class="block px-3 py-2.5 rounded hover:bg-white/15">Bayaran</a>
                 <a href="#hubungi" class="block px-3 py-2.5 rounded hover:bg-white/15">Hubungi Kami</a>
                 <div class="mt-1 pt-1 border-t border-white/15">
@@ -177,7 +175,7 @@
                     TENTANG KAMI
                 </h2>
                 <p class="mt-4 leading-relaxed text-white/75">
-                    Reniu (No. Pendaftaran: 202003286749 | SA0554424-W) telah beroperasi sejak tahun 2020 dan terus berkembang sebagai syarikat yang pakar dalam bidang tuntutan insurans & takaful. Dengan pengalaman luas, kami telah membantu ramai pelanggan mendapatkan penyelesaian terbaik dalam urusan insurans dan takaful mereka.
+                    {{ site()->legal('entity') }} (No. Pendaftaran: {{ site()->legal('registration') }}) telah beroperasi dan terus berkembang sebagai syarikat yang pakar dalam bidang tuntutan insurans & takaful. Dengan pengalaman luas, kami telah membantu ramai pelanggan mendapatkan penyelesaian terbaik dalam urusan insurans dan takaful mereka.
                 </p>
             </div>
             <div class="col-span-12 md:col-span-6">
@@ -410,33 +408,6 @@
     </div>
 </section>
 
-<!-- ══ §9 BLOG — placeholder, to be implemented ═════════════════════════ -->
-<section id="blog" class="py-16 sm:py-20">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="grid grid-cols-12">
-            <div class="col-span-12 text-center">
-                <h2 class="font-display font-bold uppercase text-2xl sm:text-3xl text-brand-ink">Artikel Terkini</h2>
-                <p class="mt-3 text-brand-muted">Seksyen blog akan dilaksanakan kemudian.</p>
-            </div>
-        </div>
-
-        <div class="grid grid-cols-12 gap-5 mt-10">
-            @for($i = 0; $i < 3; $i++)
-                <div class="col-span-12 sm:col-span-6 lg:col-span-4">
-                    <div class="h-full rounded-xl border border-brand-tint overflow-hidden bg-white">
-                        <x-img-slot class="aspect-[16/9] rounded-none border-0">Imej Artikel</x-img-slot>
-                        <div class="p-5">
-                            <p class="text-xs uppercase tracking-wide text-brand-muted">Tarikh</p>
-                            <h3 class="mt-1 font-semibold text-brand-ink">Tajuk Artikel</h3>
-                            <p class="mt-2 text-sm text-brand-muted">Petikan ringkas artikel.</p>
-                        </div>
-                    </div>
-                </div>
-            @endfor
-        </div>
-    </div>
-</section>
-
 {{-- §10 CONTACT — info only; the contact form belongs to the main site --}}
 <section id="hubungi" class="bg-[#FFF7F1] py-16 sm:py-20">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -453,8 +424,7 @@
                 <div>
                     <dt class="font-display uppercase text-xs tracking-wide text-[#E2661F]">Alamat</dt>
                     <dd class="mt-1 leading-relaxed">
-                        No 17A, Tingkat Atas Ruangniaga Sinar Mekar Abadi (RSMA),<br>
-                        Jalan Kangsar, 33000 Kuala Kangsar, Perak.
+                        {!! site()->legal('address') !!}
                     </dd>
                 </div>
                 <div>
@@ -463,7 +433,7 @@
                 </div>
                 <div>
                     <dt class="font-display uppercase text-xs tracking-wide text-[#E2661F]">E-mel</dt>
-                    <dd class="mt-1"><a href="mailto:hello@nansolutions.com.my" class="font-semibold text-brand-ink hover:text-[#E2661F] break-all">hello@nansolutions.com.my</a></dd>
+                    <dd class="mt-1"><a href="mailto:{{ site()->legal('email') }}" class="font-semibold text-brand-ink hover:text-[#E2661F] break-all">{{ site()->legal('email') }}</a></dd>
                 </div>
                 <div>
                     <dt class="font-display uppercase text-xs tracking-wide text-[#E2661F]">Waktu Operasi</dt>
@@ -486,14 +456,13 @@
             <p class="mt-3 leading-relaxed max-w-sm">
                 Perkhidmatan pembaharuan insurans kenderaan, cukai jalan dan takaful dengan pilihan bayaran ansuran.
             </p>
-            <p class="mt-3 text-white/50 text-xs">No. Pendaftaran: 202003286749 | SA0554424-W</p>
+            <p class="mt-3 text-white/50 text-xs">No. Pendaftaran: {{ site()->legal('registration') }}</p>
         </div>
         <div class="col-span-6 sm:col-span-3">
             <h4 class="font-display uppercase text-[#F0813A] text-xs tracking-widest">Pautan</h4>
             <ul class="mt-3 space-y-2">
                 <li><a href="#tentang" class="hover:text-[#F0813A]">Tentang Kami</a></li>
                 <li><a href="#rakan" class="hover:text-[#F0813A]">Rakan Insurans</a></li>
-                <li><a href="#blog" class="hover:text-[#F0813A]">Blog</a></li>
                 <li><a href="#hubungi" class="hover:text-[#F0813A]">Hubungi Kami</a></li>
             </ul>
         </div>

--- a/tests/Feature/MultiSiteTest.php
+++ b/tests/Feature/MultiSiteTest.php
@@ -214,6 +214,20 @@ class MultiSiteTest extends TestCase
         $this->get('http://reniu.my/service-delivery-policy')->assertOk();
     }
 
+    /** The legal pages carry each site's own company identity. */
+    public function test_legal_pages_show_the_sites_own_company(): void
+    {
+        $reniu = $this->get('http://reniu.my/privacy-policy')->assertOk()->getContent();
+        $this->assertStringContainsString('MY RENIU AGENCY', $reniu);
+        $this->assertStringContainsString('hello@reniu.my', $reniu);
+        $this->assertStringNotContainsString('Nan Solutions', $reniu);
+
+        $nan = $this->get('http://nansolutions.com.my/privacy-policy')->assertOk()->getContent();
+        $this->assertStringContainsString('Nan Solutions', $nan);
+        $this->assertStringContainsString('hello@nansolutions.com.my', $nan);
+        $this->assertStringNotContainsString('RENIU', $nan);
+    }
+
     /** The Reniu landing must not link to routes reniu doesn't expose. */
     public function test_reniu_landing_has_no_quote_or_lookup_links(): void
     {

--- a/tests/Feature/PaymentWhatsAppTest.php
+++ b/tests/Feature/PaymentWhatsAppTest.php
@@ -66,6 +66,15 @@ class PaymentWhatsAppTest extends TestCase
         });
     }
 
+    /** reniu payments use their own approved template; NAN payments don't. */
+    public function test_reniu_payments_use_the_reniu_template(): void
+    {
+        $payment = $this->pendingPayment();
+        $payment->update(['site' => 'reniu', 'status' => 'paid', 'paid_at' => now()]);
+
+        Http::assertSent(fn ($request) => $request['template']['name'] === 'payment_received_reniu');
+    }
+
     /** {{1}} name, {{2}} amount, {{3}} payment method — as the template expects. */
     public function test_it_sends_the_payer_name_amount_and_method_as_parameters(): void
     {


### PR DESCRIPTION
- Company identity (name, entity, registration, address, email) is now per-site config, exposed via site()->legal(). The shared legal pages and the reniu landing read from it, so reniu.my shows MY RENIU AGENCY / 202603051585 / Seri Manjung / hello@reniu.my while NAN Solutions is unchanged (its legal pages keep the registered DPO address).
- Successful reniu payments fire the payment_received_reniu WhatsApp template (same three variables); NAN payments still use payment_received.
- Removed the Artikel (blog) placeholder section and its nav links from the reniu landing.