### PR TITLE
Verify DOKU notifications against canonical body forms

### DIFF
--- a/app/Services/Payments/SenangPayGateway.php
+++ b/app/Services/Payments/SenangPayGateway.php
@@ -118,53 +118,70 @@ class SenangPayGateway implements PaymentGateway, SiteAwareGateway
     {
         $secretKey = $this->cfg('secret_key');
         $rawBody   = $request->getContent();
+        $received  = (string) $request->header('Signature');
 
-        $digest   = base64_encode(hash('sha256', $rawBody, true));
-        $received = (string) $request->header('Signature');
+        // The digest is Base64(SHA256(body)) — but DOKU may hash a canonical
+        // (minified / differently-escaped) form of the JSON, not the exact bytes
+        // we received. Try each so a formatting difference doesn't reject a
+        // genuine notification. Labelled so a match tells us which form is right.
+        $decoded        = json_decode($rawBody, true);
+        $digestVariants = ['raw' => base64_encode(hash('sha256', $rawBody, true))];
+        if (is_array($decoded)) {
+            $digestVariants['minified']           = base64_encode(hash('sha256', json_encode($decoded), true));
+            $digestVariants['minified_noslashes'] = base64_encode(hash('sha256', json_encode($decoded, JSON_UNESCAPED_SLASHES), true));
+            $digestVariants['minified_unicode']   = base64_encode(hash('sha256', json_encode($decoded, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), true));
+        }
 
-        // DOKU tells us which Request-Target it signed with, in a header of that
-        // name — trust that first. We used to assume it was the path we were
-        // POSTed to, which silently rejected every live notification.
-        //
-        // Taking the target from a header is safe: forging the signature still
-        // requires the secret key, so a wrong or hostile value just fails to match.
+        // DOKU announces its Request-Target in a header; it can also arrive doubled
+        // through a proxy ("path, path"), so include the first segment too.
+        $header = (string) $request->header('Request-Target');
         $targets = array_values(array_filter(array_unique([
-            $request->header('Request-Target'),
+            $header,
+            trim(explode(',', $header)[0]),
             $request->getPathInfo(),      // /webhooks/payments/senangpay
-            $request->getRequestUri(),    // as above, plus any query string
+            $request->getRequestUri(),
             $request->fullUrl(),
         ])));
 
-        foreach ($targets as $target) {
-            $component = "Client-Id:" . $request->header('Client-Id') . "\n"
-                . "Request-Id:" . $request->header('Request-Id') . "\n"
-                . "Request-Timestamp:" . $request->header('Request-Timestamp') . "\n"
-                . "Request-Target:" . $target . "\n"
-                . "Digest:" . $digest;
+        foreach ($digestVariants as $digestLabel => $digest) {
+            foreach ($targets as $target) {
+                $component = "Client-Id:" . $request->header('Client-Id') . "\n"
+                    . "Request-Id:" . $request->header('Request-Id') . "\n"
+                    . "Request-Timestamp:" . $request->header('Request-Timestamp') . "\n"
+                    . "Request-Target:" . $target . "\n"
+                    . "Digest:" . $digest;
 
-            // DOKU sends the Signature as raw base64 (no "HMACSHA256=" prefix) on
-            // notifications, though its request docs show the prefix — accept either.
-            $rawSignature = base64_encode(hash_hmac('sha256', $component, $secretKey, true));
+                // DOKU sends the Signature as raw base64 (no "HMACSHA256=" prefix)
+                // on notifications, though its request docs show it — accept either.
+                $rawSignature = base64_encode(hash_hmac('sha256', $component, $secretKey, true));
 
-            if (hash_equals('HMACSHA256=' . $rawSignature, $received) || hash_equals($rawSignature, $received)) {
-                $matched = $target;
-                break;
+                if (hash_equals('HMACSHA256=' . $rawSignature, $received) || hash_equals($rawSignature, $received)) {
+                    // TEMPORARY: record the winning formula (no PII) so we can pin
+                    // verifyCallback to exactly it and drop this brute-force.
+                    if ($digestLabel !== 'raw' || $target !== $request->getPathInfo()) {
+                        Log::info('senangPay (DOKU) signature matched a non-default formula.', [
+                            'digest_form' => $digestLabel,
+                            'target'      => $target,
+                            'site'        => $this->site(),
+                        ]);
+                    }
+                    $matched = true;
+                    break 2;
+                }
             }
         }
 
         if (! isset($matched)) {
-            // Fail closed. Deliberately no request body here — it carries the
-            // payer's name, email and phone, which must not reach the log file.
+            // Fail closed. No request body — it carries the payer's PII.
             Log::warning('senangPay (DOKU) signature verification failed.', [
                 'ip'                => $request->ip(),
                 'received'          => $received,
                 'targets_tried'     => $targets,
-                'client_id_header'  => $request->header('Client-Id'),
+                'digest_forms'      => array_keys($digestVariants),
                 'client_id_matches' => $request->header('Client-Id') === $this->cfg('client_id'),
                 'site'              => $this->site(),
                 'request_id'        => $request->header('Request-Id'),
                 'request_timestamp' => $request->header('Request-Timestamp'),
-                'digest_computed'   => $digest,
                 'body_bytes'        => strlen($rawBody),
             ]);
             throw new GatewayException('senangPay signature verification failed.');

--- a/tests/Feature/SenangPayGatewayTest.php
+++ b/tests/Feature/SenangPayGatewayTest.php
@@ -221,6 +221,38 @@ class SenangPayGatewayTest extends TestCase
     }
 
     /**
+     * The suspected production cause: DOKU hashes the minified JSON for the
+     * digest, but the body we receive has whitespace. Hashing the raw bytes then
+     * mismatches. Verification must recover by trying the minified form.
+     */
+    public function test_verify_callback_accepts_a_digest_over_the_minified_body(): void
+    {
+        $payload = ['order' => ['invoice_number' => 'PAY-2026-0001'], 'transaction' => ['status' => 'SUCCESS', 'original_request_id' => 'txn-min']];
+
+        $pretty   = json_encode($payload, JSON_PRETTY_PRINT);   // what arrives, with whitespace
+        $minified = json_encode($payload);                       // what DOKU signed
+        $path     = '/webhooks/payments/senangpay';
+        $digest   = base64_encode(hash('sha256', $minified, true));
+
+        $component = "Client-Id:" . self::CLIENT_ID . "\n"
+            . "Request-Id:req-min\n"
+            . "Request-Timestamp:2026-07-28T03:38:28Z\n"
+            . "Request-Target:{$path}\n"
+            . "Digest:{$digest}";
+        $signature = base64_encode(hash_hmac('sha256', $component, self::SECRET, true));
+
+        $request = Request::create($path, 'POST', [], [], [], [
+            'HTTP_CLIENT_ID'         => self::CLIENT_ID,
+            'HTTP_REQUEST_ID'        => 'req-min',
+            'HTTP_REQUEST_TIMESTAMP' => '2026-07-28T03:38:28Z',
+            'HTTP_SIGNATURE'         => $signature,
+            'CONTENT_TYPE'           => 'application/json',
+        ], $pretty);
+
+        $this->assertSame('paid', app(SenangPayGateway::class)->verifyCallback($request)['status']);
+    }
+
+    /**
      * Build a Request carrying a DOKU-style notification signed exactly the way
      * the driver's verifier recomputes it (Request-Target = our webhook path).
      */


### PR DESCRIPTION
DOKU notifications have never verified on either site: the recompute matched neither the received signature, even with the correct client-id and secret (payments create fine, so the key is right). The remaining variable is the digest — DOKU very likely hashes the minified JSON while we hashed the raw bytes as received, so any whitespace difference rejected a genuine callback.

verifyCallback now tries the digest over each canonical body form (raw, minified, minified without escaped slashes, minified unescaped-unicode) and each Request-Target (including the first segment when a proxy doubles the header). A genuine notification matches one of them; a forged one still matches none, so it stays fail-closed. When a non-default form wins it logs just the form name — no PII — so we can pin verifyCallback to exactly it and drop the brute-force.

Locks in the minified-body case with a test.