### PR TITLE
Give Allianz its own towing and PA lists on every type

### DIFF
--- a/app/Models/QuoteTemplate.php
+++ b/app/Models/QuoteTemplate.php
@@ -57,6 +57,7 @@ class QuoteTemplate extends Model
         '150km'     => '150 KM',
         '200km'     => '200 KM',
         '300km'     => '300 KM',
+        '450km'     => '450 KM',
         'unlimited' => 'UNLIMITED',
         'no'        => 'NO',
     ];
@@ -68,7 +69,7 @@ class QuoteTemplate extends Model
         'TAKAFUL IKHLAS'   => ['150km', 'unlimited', 'no'],
         'TAKAFUL MALAYSIA' => ['300km', 'unlimited', 'no'],
         'KURNIA INSURANS'  => ['100km', 'unlimited'],
-        'ALLIANZ'          => ['150km', 'unlimited', 'no'],   // same list as Takaful Ikhlas
+        'ALLIANZ'          => ['150km', '450km', 'unlimited'],
     ];
 
     public const NCD_OPTIONS = [
@@ -87,6 +88,7 @@ class QuoteTemplate extends Model
         'motorist_plan_3'       => 'MOTORIST PLAN 3',
         'motorist_plan_4'       => 'MOTORIST PLAN 4',
         'auto365'               => 'AUTO365',
+        'road_warrior'          => 'ROAD WARRIOR',
         'enhanced_road_warrior' => 'ENHANCED ROAD WARRIOR',
         'bike_warrior'          => 'BIKE WARRIOR',
     ];
@@ -97,7 +99,7 @@ class QuoteTemplate extends Model
         'TAKAFUL IKHLAS'   => ['yes', 'no', 'cash_care'],
         'TAKAFUL MALAYSIA' => ['yes', 'no', 'cash_care', 'motorist_plan_3', 'motorist_plan_4'],
         'KURNIA INSURANS'  => ['auto365'],
-        'ALLIANZ'          => ['enhanced_road_warrior'],
+        'ALLIANZ'          => ['road_warrior', 'enhanced_road_warrior'],
     ];
 
     /** Multi-select benefits on the motor quotes (each shows as its own line). */
@@ -182,6 +184,8 @@ class QuoteTemplate extends Model
                 'companies' => $all,
                 'ncd'       => self::NCD_OPTIONS,
                 'towing'    => ['no_towing', 'unlimited'],
+                // Allianz quotes its own towing on this type, not the type-wide list.
+                'company_towing' => ['ALLIANZ' => self::COMPANY_TOWING['ALLIANZ']],
                 'sections'  => [
                     'Sebut Harga'        => ['sum_covered', 'value'],
                     'Insurance Benefits' => ['towing', 'accident_assist', 'ncd'],
@@ -196,9 +200,9 @@ class QuoteTemplate extends Model
                 'companies' => $motor,
                 'ncd'       => self::NCD_MOTOR_OPTIONS,
                 'towing'    => ['no_towing', 'unlimited', '50km', '30km'],
-                // Allianz quotes different cover on this type than the others.
-                'company_towing' => ['ALLIANZ' => ['unlimited', 'no']],
-                'company_pa'     => ['ALLIANZ' => ['bike_warrior', 'no']],
+                // Allianz quotes its own towing here too. Its PA needs no override:
+                // this type sets no PA list, so COMPANY_PA already applies.
+                'company_towing' => ['ALLIANZ' => self::COMPANY_TOWING['ALLIANZ']],
                 'sections'  => [
                     'Sebut Harga'        => ['sum_covered', 'value'],
                     'Insurance Benefits' => ['all_rider', 'accident_assist', 'ncd', 'additional_benefits'],

--- a/tests/Feature/QuoteTemplateTest.php
+++ b/tests/Feature/QuoteTemplateTest.php
@@ -314,30 +314,38 @@ class QuoteTemplateTest extends TestCase
 
     public function test_allianz_option_lists_differ_by_quote_type(): void
     {
-        // Comprehensive: towing mirrors Takaful Ikhlas, PA is Enhanced Road Warrior.
+        // Comprehensive: Allianz's own lists, in the order given.
         $this->assertSame(
-            QuoteTemplate::optionsFor('towing', 'comprehensive', 'TAKAFUL IKHLAS'),
+            ['150km' => '150 KM', '450km' => '450 KM', 'unlimited' => 'UNLIMITED'],
             QuoteTemplate::optionsFor('towing', 'comprehensive', 'ALLIANZ')
         );
         $this->assertSame(
-            ['enhanced_road_warrior' => 'ENHANCED ROAD WARRIOR'],
+            ['road_warrior' => 'ROAD WARRIOR', 'enhanced_road_warrior' => 'ENHANCED ROAD WARRIOR'],
             QuoteTemplate::optionsFor('personal_accident', 'comprehensive', 'ALLIANZ')
         );
 
-        // 1st Party Motor overrides both, for Allianz only.
+        // Allianz keeps its own lists even on the types that set a towing list
+        // for everyone else (3rd Party & Theft, 1st Party Motor).
+        foreach (['third_party_fire_theft', 'motor_first_party'] as $type) {
+            $this->assertSame(
+                ['150km' => '150 KM', '450km' => '450 KM', 'unlimited' => 'UNLIMITED'],
+                QuoteTemplate::optionsFor('towing', $type, 'ALLIANZ'),
+                "towing wrong on {$type}"
+            );
+        }
         $this->assertSame(
-            ['unlimited' => 'UNLIMITED', 'no' => 'NO'],
-            QuoteTemplate::optionsFor('towing', 'motor_first_party', 'ALLIANZ')
-        );
-        $this->assertSame(
-            ['bike_warrior' => 'BIKE WARRIOR', 'no' => 'NO'],
+            ['road_warrior' => 'ROAD WARRIOR', 'enhanced_road_warrior' => 'ENHANCED ROAD WARRIOR'],
             QuoteTemplate::optionsFor('personal_accident', 'motor_first_party', 'ALLIANZ')
         );
 
-        // The override must not leak to the other insurers on that type.
+        // That must not leak to the other insurers on those types.
         $this->assertSame(
             ['no_towing' => 'NO TOWING', 'unlimited' => 'UNLIMITED', '50km' => '50 KM', '30km' => '30 KM'],
             QuoteTemplate::optionsFor('towing', 'motor_first_party', 'ZURICH TAKAFUL')
+        );
+        $this->assertSame(
+            ['no_towing' => 'NO TOWING', 'unlimited' => 'UNLIMITED'],
+            QuoteTemplate::optionsFor('towing', 'third_party_fire_theft', 'ETIQA TAKAFUL')
         );
     }
 
@@ -345,7 +353,7 @@ class QuoteTemplateTest extends TestCase
     {
         $payload = $this->payloadFor('motor_first_party', ['ALLIANZ']);
         $payload['columns'][0]['towing']            = 'unlimited';
-        $payload['columns'][0]['personal_accident'] = 'bike_warrior';
+        $payload['columns'][0]['personal_accident'] = 'road_warrior';
 
         $this->actingAs($this->admin())
             ->post(route('quote-templates.store'), $payload)
@@ -353,7 +361,7 @@ class QuoteTemplateTest extends TestCase
 
         $column = QuoteTemplate::firstOrFail()->data['columns'][0];
         $this->assertSame('ALLIANZ', $column['company']);
-        $this->assertSame('bike_warrior', $column['personal_accident']);
+        $this->assertSame('road_warrior', $column['personal_accident']);
     }
 
     /** The stored shape (what validated() writes), for model-level assertions. */


### PR DESCRIPTION
Towing becomes 150 KM / 450 KM / Unlimited and PA becomes Road Warrior / Enhanced Road Warrior. 450 KM and Road Warrior are new labels.

These lists now win on the two types that otherwise set towing for every insurer, so Allianz reads the same everywhere it appears rather than silently falling back to the type-wide list on 3rd Party & Theft. The override points at COMPANY_TOWING['ALLIANZ'] instead of repeating the values, so the three types cannot drift apart. 1st Party Motor no longer overrides PA either — that type sets no PA list, so the company list already applies.

Other insurers are unaffected: 3rd Party & Theft still quotes No Towing / Unlimited for them, and 1st Party Motor still quotes its four options, both asserted.

BIKE WARRIOR stays in the option list although no company now offers it, so any quote already saved with it still renders its label.