### PR TITLE
Shrink blog uploads on the way in

### DIFF
--- a/app/Http/Controllers/BlogPostController.php
+++ b/app/Http/Controllers/BlogPostController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use App\Models\BlogCategory;
 use App\Models\BlogPost;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class BlogPostController extends Controller
 {
@@ -79,7 +81,7 @@ class BlogPostController extends Controller
     {
         $request->validate(['file' => 'required|image|max:5120']);
 
-        $path = $request->file('file')->store('blog/inline', 'public');
+        $path = $this->storeOptimised($request->file('file'), 'blog/inline');
 
         return response()->json(['url' => Storage::disk('public')->url($path)]);
     }
@@ -116,9 +118,131 @@ class BlogPostController extends Controller
             if ($existing?->cover_image) {
                 Storage::disk('public')->delete($existing->cover_image);
             }
-            $data['cover_image'] = $request->file('cover')->store('blog/covers', 'public');
+            $data['cover_image'] = $this->storeOptimised($request->file('cover'), 'blog/covers');
         }
 
         return $data;
+    }
+
+    /**
+     * Store an upload at a sane size. Phone and camera images arrive several
+     * thousand pixels wide, far more than the blog renders, so they are capped
+     * on the long edge.
+     *
+     * Format is chosen by measuring both encodings rather than by rule: JPEG
+     * usually wins for photographs, but a screenshot or flat graphic often
+     * encodes smaller as PNG, and forcing that to JPEG would inflate the file
+     * and soften it. If neither beats the original and no resize was needed,
+     * the upload is stored untouched, as is anything GD cannot read.
+     */
+    private function storeOptimised(UploadedFile $file, string $directory, int $max = 1600): string
+    {
+        $original = (string) file_get_contents($file->getRealPath());
+        $image    = @imagecreatefromstring($original);
+
+        if (! $image) {
+            return $file->store($directory, 'public');
+        }
+
+        $width   = imagesx($image);
+        $height  = imagesy($image);
+        $scale   = min($max / $width, $max / $height, 1);   // never enlarge
+        $resized = $scale < 1;
+
+        if ($resized) {
+            $smaller = imagecreatetruecolor((int) round($width * $scale), (int) round($height * $scale));
+            imagealphablending($smaller, false);
+            imagesavealpha($smaller, true);
+            imagecopyresampled(
+                $smaller, $image, 0, 0, 0, 0,
+                imagesx($smaller), imagesy($smaller), $width, $height
+            );
+            imagedestroy($image);
+            $image = $smaller;
+        }
+
+        $candidates = ['png' => $this->encodePng($image)];
+        if (! $this->hasTransparency($image)) {
+            $candidates['jpg'] = $this->encodeJpeg($image);
+        }
+        imagedestroy($image);
+
+        // Compare by length: min() on binary strings compares bytewise, and a
+        // PNG (0x89...) always sorts below a JPEG (0xFF...) whatever its size.
+        // Compare by length: min() on binary strings compares bytewise, and a
+        // PNG (0x89...) always sorts below a JPEG (0xFF...) whatever its size.
+        $extension = 'png';
+        if (isset($candidates['jpg']) && strlen($candidates['jpg']) < strlen($candidates['png'])) {
+            $extension = 'jpg';
+        }
+        $binary = $candidates[$extension];
+
+        // Re-encoding can beat nothing on an already-optimised file.
+        if (! $resized && strlen($binary) >= strlen($original)) {
+            return $file->store($directory, 'public');
+        }
+
+        $path = $directory . '/' . Str::random(40) . '.' . $extension;
+        Storage::disk('public')->put($path, $binary);
+
+        return $path;
+    }
+
+    /** @param \GdImage $image */
+    private function encodePng($image): string
+    {
+        imagesavealpha($image, true);
+        ob_start();
+        // Level 6, not 9: on a 1254px cover, 9 cost 4.3s to beat 6 by 3%.
+        imagepng($image, null, 6);
+
+        return (string) ob_get_clean();
+    }
+
+    /**
+     * JPEG has no alpha, so the image is composited onto white first. Without
+     * that, GD renders every transparent pixel black.
+     *
+     * @param \GdImage $image
+     */
+    private function encodeJpeg($image): string
+    {
+        $flat = imagecreatetruecolor(imagesx($image), imagesy($image));
+        imagefilledrectangle($flat, 0, 0, imagesx($flat), imagesy($flat), imagecolorallocate($flat, 255, 255, 255));
+        imagealphablending($flat, true);
+        imagecopy($flat, $image, 0, 0, 0, 0, imagesx($image), imagesy($image));
+
+        ob_start();
+        imagejpeg($flat, null, 82);
+        $binary = (string) ob_get_clean();
+        imagedestroy($flat);
+
+        return $binary;
+    }
+
+    /**
+     * Whether any pixel is actually see-through. The PNG header is no use:
+     * editors routinely export fully opaque images as RGBA, which would rule out
+     * JPEG for the very photographs that gain most from it — one 1.9MB cover was
+     * colour type 6 with not a single transparent pixel, and JPEG took it to
+     * 262KB. Sampled on a stride so the scan stays cheap on a large image.
+     *
+     * @param \GdImage $image
+     */
+    private function hasTransparency($image): bool
+    {
+        $width  = imagesx($image);
+        $height = imagesy($image);
+        $step   = max(1, (int) sqrt($width * $height / 40000));
+
+        for ($x = 0; $x < $width; $x += $step) {
+            for ($y = 0; $y < $height; $y += $step) {
+                if (((imagecolorat($image, $x, $y) >> 24) & 0x7F) > 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Feature/BlogTest.php
+++ b/tests/Feature/BlogTest.php
@@ -103,4 +103,77 @@ class BlogTest extends TestCase
         // …but the admin area is not.
         $this->get(route('blog-posts.index'))->assertRedirect();
     }
+
+    /**
+     * Uploads arrive straight off a phone or camera at several thousand pixels
+     * wide — one 1.9MB cover came through untouched — so they are capped and
+     * re-encoded on the way in.
+     */
+    public function test_an_oversized_cover_is_shrunk_on_upload(): void
+    {
+        $source = $this->photograph(3000, 2200);
+
+        $this->actingAs($this->admin())->post(route('blog-posts.store'), [
+            'title' => 'Big Cover',
+            'body'  => 'x',
+            'cover' => new UploadedFile($source, 'huge.jpg', 'image/jpeg', null, true),
+        ])->assertRedirect();
+
+        $stored = BlogPost::sole()->cover_image;
+        Storage::disk('public')->assertExists($stored);
+
+        [$width, $height] = getimagesize(Storage::disk('public')->path($stored));
+        $this->assertLessThanOrEqual(1600, max($width, $height), 'cover was not resized');
+
+        // Aspect ratio preserved.
+        $this->assertEqualsWithDelta(3000 / 2200, $width / $height, 0.01);
+
+        $this->assertLessThan(
+            filesize($source),
+            Storage::disk('public')->size($stored),
+            'stored cover is not smaller than the upload'
+        );
+
+        @unlink($source);
+    }
+
+    /** Flattening a transparent image to JPEG would black out its background. */
+    public function test_a_transparent_upload_stays_png(): void
+    {
+        $image = imagecreatetruecolor(400, 400);
+        imagesavealpha($image, true);
+        imagealphablending($image, false);
+        imagefill($image, 0, 0, imagecolorallocatealpha($image, 255, 0, 0, 90));
+        $source = tempnam(sys_get_temp_dir(), 'alpha') . '.png';
+        imagepng($image, $source);
+        imagedestroy($image);
+
+        $this->actingAs($this->admin())->post(route('blog-posts.store'), [
+            'title' => 'Transparent',
+            'body'  => 'x',
+            'cover' => new UploadedFile($source, 'logo.png', 'image/png', null, true),
+        ])->assertRedirect();
+
+        $this->assertSame('png', pathinfo(BlogPost::sole()->cover_image, PATHINFO_EXTENSION));
+
+        @unlink($source);
+    }
+
+    /** A JPEG with detail, which is what a camera actually produces. */
+    private function photograph(int $width, int $height): string
+    {
+        $image = imagecreatetruecolor($width, $height);
+        for ($x = 0; $x < $width; $x += 2) {
+            for ($y = 0; $y < $height; $y += 2) {
+                imagefilledrectangle($image, $x, $y, $x + 2, $y + 2, imagecolorallocate(
+                    $image, ($x * 7 + $y) % 255, ($y * 11) % 255, ($x + $y * 3) % 255
+                ));
+            }
+        }
+        $path = tempnam(sys_get_temp_dir(), 'photo') . '.jpg';
+        imagejpeg($image, $path, 95);
+        imagedestroy($image);
+
+        return $path;
+    }
 }


### PR DESCRIPTION
A cover uploaded straight from a phone was stored byte-for-byte: 1.9MB at 1254px for a slot the blog renders a few hundred pixels wide.

Uploads are now capped at 1600px on the long edge and re-encoded. Format is decided by encoding both ways and keeping the smaller file, because the answer varies: photographs shrink hugely as JPEG, while screenshots and flat graphics encode smaller as PNG and would be both inflated and softened by converting them. If neither beats the original and no resize was needed the upload is stored untouched, as is anything GD cannot decode.

Transparency is decided by sampling pixels, not by reading the PNG header. Editors routinely export fully opaque images as RGBA, and trusting the header ruled out JPEG for exactly the photographs that gain most from it — the 1.9MB cover was colour type 6 without a single transparent pixel. Images that really are transparent stay PNG; a JPEG candidate is composited onto white first, so a missed edge case degrades to a white background rather than the black GD would otherwise write.

Measured on the real cover: 1875KB -> 262KB (-86%), 690ms. A genuinely transparent logo stays PNG and keeps its alpha.