### PR TITLE
Uppercase the quote PDF filename

### DIFF
--- a/app/Http/Controllers/QuoteTemplateController.php
+++ b/app/Http/Controllers/QuoteTemplateController.php
@@ -103,7 +103,9 @@ class QuoteTemplateController extends Controller
                 : (is_file(public_path('images/logo.png')) ? public_path('images/logo.png') : null)
         );
 
-        $filename = 'sebut-harga-' . Str::slug($quoteTemplate->vehicle_reg_number ?: 'quote') . '.pdf';
+        // Str::slug() lowercases, so uppercase after slugging. The extension stays
+        // lowercase — some clients match it case-sensitively.
+        $filename = Str::upper('sebut-harga-' . Str::slug($quoteTemplate->vehicle_reg_number ?: 'quote')) . '.pdf';
 
         return Pdf::loadView('quote-templates.pdf', [
             'template'  => $quoteTemplate,

--- a/tests/Feature/QuoteTemplateTest.php
+++ b/tests/Feature/QuoteTemplateTest.php
@@ -257,7 +257,10 @@ class QuoteTemplateTest extends TestCase
 
         $response->assertOk();
         $this->assertSame('application/pdf', $response->headers->get('content-type'));
-        $this->assertStringContainsString('.pdf', $response->headers->get('content-disposition'));
+
+        // Filename is uppercase; the reg number would otherwise be lowercased by slug().
+        $disposition = $response->headers->get('content-disposition');
+        $this->assertStringContainsString('SEBUT-HARGA-WXY1234.pdf', $disposition);
         $this->assertStringStartsWith('%PDF', $response->getContent());
     }
 


### PR DESCRIPTION
Str::slug() lowercases, so a plate saved as PCG8069 downloaded as sebut-harga-pcg8069.pdf. Uppercased after slugging; the extension stays lowercase because some clients match it case-sensitively.