### PR TITLE
Offer Takaful Ikhlas on 1st Party (Motor) too

### DIFF
--- a/app/Models/QuoteTemplate.php
+++ b/app/Models/QuoteTemplate.php
@@ -35,7 +35,7 @@ class QuoteTemplate extends Model
     ];
 
     /** The motor quote types compare these. */
-    public const MOTOR_COMPANIES = ['ZURICH TAKAFUL', 'ETIQA TAKAFUL', 'TAKAFUL MALAYSIA', 'ALLIANZ'];
+    public const MOTOR_COMPANIES = ['ZURICH TAKAFUL', 'ETIQA TAKAFUL', 'TAKAFUL IKHLAS', 'TAKAFUL MALAYSIA', 'ALLIANZ'];
 
     // ── Option maps ───────────────────────────────────────────────────────────
 
@@ -214,9 +214,7 @@ class QuoteTemplate extends Model
             'motor_third_party' => [
                 'label'     => '3rd Party (Motor)',
                 'title'     => 'Motor Third Party',
-                // Takaful Ikhlas is quoted on this type but not the other motor
-                // one, so it is listed here rather than added to MOTOR_COMPANIES.
-                'companies' => [...$motor, 'TAKAFUL IKHLAS'],
+                'companies' => $motor,
                 'ncd'       => self::NCD_MOTOR_OPTIONS,
                 'sections'  => [
                     'Sebut Harga'        => ['sum_covered'],

--- a/tests/Feature/QuoteTemplateTest.php
+++ b/tests/Feature/QuoteTemplateTest.php
@@ -442,19 +442,20 @@ class QuoteTemplateTest extends TestCase
         ];
     }
 
-    /**
-     * Takaful Ikhlas is quoted on 3rd Party (Motor) but not 1st Party (Motor),
-     * so it is listed on that type rather than added to MOTOR_COMPANIES.
-     */
-    public function test_takaful_ikhlas_is_offered_on_motor_third_party_only(): void
+    /** Takaful Ikhlas is quoted on every type, motor included. */
+    public function test_takaful_ikhlas_is_offered_on_every_type(): void
     {
-        $this->assertContains('TAKAFUL IKHLAS', QuoteTemplate::companiesForType('motor_third_party'));
-        $this->assertNotContains('TAKAFUL IKHLAS', QuoteTemplate::companiesForType('motor_first_party'));
-
-        // The other insurers on that type are untouched.
-        foreach (['ZURICH TAKAFUL', 'ETIQA TAKAFUL', 'TAKAFUL MALAYSIA', 'ALLIANZ'] as $company) {
-            $this->assertContains($company, QuoteTemplate::companiesForType('motor_third_party'));
+        foreach (array_keys(QuoteTemplate::types()) as $type) {
+            $this->assertContains('TAKAFUL IKHLAS', QuoteTemplate::companiesForType($type), "missing on {$type}");
         }
+
+        // The other motor insurers are untouched.
+        foreach (['ZURICH TAKAFUL', 'ETIQA TAKAFUL', 'TAKAFUL MALAYSIA', 'ALLIANZ'] as $company) {
+            $this->assertContains($company, QuoteTemplate::companiesForType('motor_first_party'));
+        }
+
+        // Kurnia remains non-motor.
+        $this->assertNotContains('KURNIA INSURANS', QuoteTemplate::companiesForType('motor_first_party'));
     }
 
     public function test_a_motor_third_party_quote_can_be_saved_with_takaful_ikhlas(): void
@@ -466,14 +467,12 @@ class QuoteTemplateTest extends TestCase
         $this->assertSame('TAKAFUL IKHLAS', QuoteTemplate::firstOrFail()->data['columns'][0]['company']);
     }
 
-    /** It stays rejected on the type it is not quoted for. */
-    public function test_motor_first_party_still_rejects_takaful_ikhlas(): void
+    public function test_a_motor_first_party_quote_can_be_saved_with_takaful_ikhlas(): void
     {
-        $payload = $this->payloadFor('motor_first_party', ['ZURICH TAKAFUL']);
-        $payload['columns'][0]['company'] = 'TAKAFUL IKHLAS';
-
         $this->actingAs($this->admin())
-            ->post(route('quote-templates.store'), $payload)
-            ->assertSessionHasErrors('columns.0.company');
+            ->post(route('quote-templates.store'), $this->payloadFor('motor_first_party', ['TAKAFUL IKHLAS']))
+            ->assertSessionHasNoErrors();
+
+        $this->assertSame('TAKAFUL IKHLAS', QuoteTemplate::firstOrFail()->data['columns'][0]['company']);
     }
 }


### PR DESCRIPTION
It is quoted on both motor types after all, so it moves into MOTOR_COMPANIES and the per-type listing added for 3rd Party (Motor) goes away rather than sitting alongside a shared list that already covers it.

Placed third to match the order in ALL_COMPANIES, so the insurer sits in the same position on every type. No option lists were needed: 1st Party (Motor) sets towing for every insurer, and Takaful Ikhlas already has a personal accident list.